### PR TITLE
Make arx5-sdk a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.16.3 )
 
-project( arx5_sdk )
+project( arx5-sdk )
 
 set(CMAKE_BUILD_TYPE Debug)
 
@@ -25,43 +25,74 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64)|(^i686)")
     set(LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/x86_64)
 endif()
 
-set(cpp_source
+include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${EIGEN3_INCLUDE_DIRS})
+include_directories(
+    $ENV{CONDA_PREFIX}/include/
+    $ENV{CONDA_PREFIX}/include/urdfdom_headers
+)
+
+add_library(ArxJointController SHARED
     src/app/joint_controller.cpp
     src/utils.cpp
 )
-add_executable(test_joint_controller examples/test_joint_controller.cpp ${cpp_source})
+target_link_libraries(ArxJointController
+    ${LIB_DIR}/libhardware.so
+    ${LIB_DIR}/libsolver.so
+    Eigen3::Eigen
+    Threads::Threads
+    spdlog::spdlog
+    kdl_parser
+    orocos-kdl
+)
+add_library(ArxHighlevelController SHARED
+    src/app/high_level.cpp
+    src/utils.cpp
+)
+target_link_libraries(ArxHighlevelController
+    ${LIB_DIR}/libhardware.so
+    ${LIB_DIR}/libsolver.so
+    Eigen3::Eigen
+    Threads::Threads
+    spdlog::spdlog
+    kdl_parser
+    orocos-kdl
+)
 
+add_executable(test_joint_controller examples/test_joint_controller.cpp)
 target_link_libraries(test_joint_controller 
     ${LIB_DIR}/libhardware.so 
     ${LIB_DIR}/libsolver.so 
+    ArxJointController
     Eigen3::Eigen
     Threads::Threads
     spdlog::spdlog
     kdl_parser
     orocos-kdl
 )
-target_include_directories(test_joint_controller PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_include_directories(test_joint_controller PUBLIC ${EIGEN3_INCLUDE_DIRS})
-target_include_directories(test_joint_controller PUBLIC $ENV{CONDA_PREFIX}/include/kdl_parser  $ENV{CONDA_PREFIX}/include/urdfdom_headers)
 
-
-
-add_executable(test_high_level examples/test_high_level.cpp 
-    ${cpp_source}
-    src/app/high_level.cpp
-)  
+add_executable(test_high_level examples/test_high_level.cpp)
 target_link_libraries(test_high_level 
     ${LIB_DIR}/libhardware.so 
-    ${LIB_DIR}/libsolver.so 
+    ${LIB_DIR}/libsolver.so
+    ArxHighlevelController
     spdlog::spdlog
     Eigen3::Eigen
     Threads::Threads
     kdl_parser
     orocos-kdl
 )
-target_include_directories(test_high_level PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_include_directories(test_high_level PUBLIC ${EIGEN3_INCLUDE_DIRS})
-# Hack for py310
-target_include_directories(test_high_level PUBLIC $ENV{CONDA_PREFIX}/include/kdl_parser  $ENV{CONDA_PREFIX}/include/urdfdom_headers)
 
 add_subdirectory(python)
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}
+)
+
+install(FILES ${LIB_DIR}/libhardware.so ${LIB_DIR}/libsolver.so
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}
+)
+
+install(TARGETS ArxJointController ArxHighlevelController
+    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}
+)

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@
 - Joint controller runs at 500Hz in the background (motor communication delay ~0.4ms)
 - Control multiple arms in the same process
 
-## Install
+## Build & Install
 ```bash
 mamba env create -f conda_environment.yaml # for python3.9, or py310_environment.yaml for python3.10
 conda activate arx # arx-py310
 mkdir build && cd build
 cmake ..
 make -j
+# At this point, you should be able to run test scripts below.
+make install
 ```
 
-# CAN setup
+## CAN setup
 ``` sh
 sudo apt install can-utils
 sudo apt install net-tools
@@ -46,7 +48,7 @@ sudo slcand -o -f -s8 /dev/canable0 can0
 sudo ifconfig can0 up
 ```
 
-## Usage
+## Test scripts
 ```bash
 cd python
 python examples/test_joint_control.py

--- a/include/app/joint_controller.h
+++ b/include/app/joint_controller.h
@@ -89,6 +89,7 @@ class Arx5JointController {
   void calibrate_gripper();
   void calibrate_joint(int joint_id);
   double get_timestamp();
+  double get_dt_s();
 
   void set_log_level(spdlog::level::level_enum level);
 

--- a/src/app/joint_controller.cpp
+++ b/src/app/joint_controller.cpp
@@ -179,6 +179,10 @@ double Arx5JointController::get_timestamp() {
   return double(get_time_us() - _start_time_us) / 1e6;
 }
 
+double Arx5JointController::get_dt_s() {
+  return JOINT_CONTROLLER_DT;
+}
+
 void Arx5JointController::_send_recv() {
   // TODO: in the motor documentation, there shouldn't be these torque constant. Torque will go directly into the motors
   const double torque_constant1 = 1.4;    // Nm/A, only for the bottom 3 motors
@@ -555,3 +559,4 @@ void Arx5JointController::disable_gravity_compensation() {
   _enable_gravity_compensation = false;
   _solver.reset();
 }
+


### PR DESCRIPTION
Problem:
* The CMakeLists.txt is setup to only build executables. The controllers cannot be used outside of this package.

Solution:
* Separated library targets from executables. The executables, which are
  test scripts, now depends on the libraries.
* Added install script for the library targets and headers.
* Added install script for the .so file objects
* Rename project name to be consistent with package name, so both this
  package and downstream users can access headers using the same path
* Added a getter for dt

Test: Tested execution of the joint controller in another package.